### PR TITLE
Update requirements.txt

### DIFF
--- a/python/pulumi_over_http/requirements.txt
+++ b/python/pulumi_over_http/requirements.txt
@@ -1,3 +1,4 @@
 pulumi>=3.0.0,<4.0.0
 pulumi-aws>=4.0.0,<5.0.0
 flask>=1.1.2,<2.0.0
+markupsafe==2.0.1


### PR DESCRIPTION
Pinning markupsafe, see [discussion]( https://github.com/aws/aws-sam-cli/issues/3661) 
I had error:
```
jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/alex/anaconda3/envs/pulumi_env/lib/python3.10/site-packages/markupsafe/__init__.py)
```
fix `pip install markupsafe==2.0.1`