### PR TITLE
Use the latest version of Node.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,6 +971,8 @@ jobs:
       - name: Login Local
         run: pulumi login --local
       - run: yarn install
+        working-directory: nodejs/localProgram-tsnode/website
+      - run: yarn install
         working-directory: nodejs/localProgram-tsnode/automation
       - name: Deploy app
         run: yarn start

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,7 +732,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x
   node-database-migration:
@@ -772,7 +772,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x
   node-inline-program-js:
@@ -812,7 +812,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x
   node-inline-program-ts:
@@ -852,7 +852,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x
   node-inline-program-tsnode:
@@ -892,7 +892,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x
   node-inline-secrets-provider-ts:
@@ -941,7 +941,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x
   node-local-program-tsnode:
@@ -981,6 +981,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - 20.x
         go-version:
           - 1.16.x

--- a/nodejs/localProgram-tsnode/website/index.ts
+++ b/nodejs/localProgram-tsnode/website/index.ts
@@ -2,11 +2,6 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { PolicyDocument } from "@pulumi/aws/iam";
 
-// Create an AWS resource (S3 Bucket)
-const bucket = new aws.s3.Bucket("my-bucket");
-
-// Export the name of the bucket
-export const bucketName = bucket.id;
 
 // Create a bucket and expose a website index document
 const siteBucket = new aws.s3.Bucket("s3-website-bucket", {
@@ -14,6 +9,21 @@ const siteBucket = new aws.s3.Bucket("s3-website-bucket", {
         indexDocument: "index.html",
     },
 });
+
+// Configure ownership controls for the new S3 bucket
+const ownershipControls = new aws.s3.BucketOwnershipControls("ownership-controls", {
+    bucket: siteBucket.bucket,
+    rule: {
+        objectOwnership: "ObjectWriter",
+    },
+});
+
+// Configure public ACL block on the new S3 bucket
+const publicAccessBlock = new aws.s3.BucketPublicAccessBlock("public-access-block", {
+    bucket: siteBucket.bucket,
+    blockPublicAcls: false,
+});
+
 const indexContent = `<html><head>
 <title>Hello S3</title><meta charset="UTF-8">
 </head>
@@ -23,34 +33,13 @@ const indexContent = `<html><head>
 
 // write our index.html into the site bucket
 let object = new aws.s3.BucketObject("index", {
+    acl: "public-read",
     bucket: siteBucket,
     content: indexContent,
     contentType: "text/html; charset=utf-8",
     key: "index.html"
+}, {
+    dependsOn: [ownershipControls, publicAccessBlock]
 });
-
-// Create an S3 Bucket Policy to allow public read of all objects in bucket
-function publicReadPolicyForBucket(bucketName: string): PolicyDocument {
-    return {
-        Version: "2012-10-17",
-        Statement: [{
-            Effect: "Allow",
-            Principal: "*",
-            Action: [
-                "s3:GetObject"
-            ],
-            Resource: [
-                `arn:aws:s3:::${bucketName}/*` // policy refers to bucket name explicitly
-            ]
-        }]
-    };
-}
-
-// Set the access policy for the bucket so all objects are readable
-let bucketPolicy = new aws.s3.BucketPolicy("bucketPolicy", {
-    bucket: siteBucket.bucket, // refer to the bucket created earlier
-    policy: siteBucket.bucket.apply(publicReadPolicyForBucket) // use output property `siteBucket.bucket`
-});
-
 
 export const websiteUrl = siteBucket.websiteEndpoint;

--- a/nodejs/localProgram-tsnode/website/package.json
+++ b/nodejs/localProgram-tsnode/website/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "^4.0.0",
-        "@pulumi/awsx": "^0.22.0"
+        "@pulumi/aws": "^6.0.0"
     }
 }


### PR DESCRIPTION
This fixes failures due to packages not supporting Node 14.x.

Additionally, fix the CI script for the `node-local-program-tsnode` to install dependencies for the program. This has apparently [never worked in CI](https://github.com/pulumi/automation-api-examples/actions/runs/7991360249/job/21822347128#step:10:40), but it wasn't previously reported as a failure. Now with the Node.js upgrade, it's failing in CI.

Finally, fix an actual problem with the `node-local-program-tsnode` program. It was failing with an "Access Denied" error trying to create the bucket policy. Fix this up to use the latest way of doing it.

Note: Definitely need other upgrades in this repo, but will do that subsequently.

Fixes #71