### PR TITLE
Fix `python/inline_secrets_provider` example

### DIFF
--- a/python/inline_secrets_provider/main.py
+++ b/python/inline_secrets_provider/main.py
@@ -67,7 +67,7 @@ stack_name = "dev"
 project_settings=auto.ProjectSettings(
     name=project_name,
     runtime="python",
-    backend={"url": "file://~/.pulumi-local"})
+    backend=auto.ProjectBackend(url="file://~/.pulumi-local"))
 
 secrets_provider = "awskms://aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee?region=us-west-2"
 kms_env = os.environ.get("KMS_KEY")


### PR DESCRIPTION
The `backend` arg must be passed as a `ProjectBackend` instance, rather than as a dict.

Fixes #74