### PR TITLE
Remove unneeded node package names

### DIFF
--- a/nodejs/crossLanguage-tsnode/automation/package.json
+++ b/nodejs/crossLanguage-tsnode/automation/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "automation",
-  "version": "1.0.0",
   "main": "index.ts",
   "repository": "github.com/pulumi/automation-api-examples",
   "author": "EvanBoyle",

--- a/nodejs/databaseMigration-ts/package.json
+++ b/nodejs/databaseMigration-ts/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "database_migration",
-  "version": "1.0.0",
   "main": "./bin/index.js",
   "repository": "github.com/pulumi/automation-api-examples",
   "author": "EvanBoyle",

--- a/nodejs/inlineProgram-js/package.json
+++ b/nodejs/inlineProgram-js/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "inline_program",
-  "version": "1.0.0",
   "main": "index.js",
   "type": "commonjs",
   "repository": "github.com/pulumi/automation-api-examples",

--- a/nodejs/inlineProgram-ts/package.json
+++ b/nodejs/inlineProgram-ts/package.json
@@ -1,12 +1,9 @@
 {
-  "name": "inline_program",
-  "version": "1.0.0",
   "main": "./bin/index.js",
   "repository": "github.com/pulumi/automation-api-examples",
   "author": "EvanBoyle",
   "license": "MIT",
   "dependencies": {
-    "@pulumi/aws": "^4.0.0",
     "@pulumi/pulumi": "^3.0.0",
     "@types/node": "^14.11.7"
   },

--- a/nodejs/inlineProgram-ts/package.json
+++ b/nodejs/inlineProgram-ts/package.json
@@ -4,6 +4,7 @@
   "author": "EvanBoyle",
   "license": "MIT",
   "dependencies": {
+    "@pulumi/aws": "^4.0.0",
     "@pulumi/pulumi": "^3.0.0",
     "@types/node": "^14.11.7"
   },

--- a/nodejs/inlineProgram-tsnode/package.json
+++ b/nodejs/inlineProgram-tsnode/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "inlineProgram",
-  "version": "1.0.0",
   "main": "index.ts",
   "repository": "github.com/pulumi/automation-api-examples",
   "author": "EvanBoyle",

--- a/nodejs/inlineSecretsProvider-ts/package.json
+++ b/nodejs/inlineSecretsProvider-ts/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "inline_program",
-  "version": "1.0.0",
   "main": "./bin/index.js",
   "repository": "github.com/pulumi/automation-api-examples",
   "author": "EvanBoyle",

--- a/nodejs/localProgram-tsnode-mochatests/package.json
+++ b/nodejs/localProgram-tsnode-mochatests/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "aws-automation-ts-s3-website",
-  "version": "1.0.0",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/nodejs/pulumiOverHttp-ts/package.json
+++ b/nodejs/pulumiOverHttp-ts/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "pulumi_over_http",
-  "version": "1.0.0",
   "main": "./bin/index.js",
   "repository": "github.com/pulumi/automation-api-examples",
   "author": "EvanBoyle",

--- a/nodejs/remoteDeployment-tsnode/package.json
+++ b/nodejs/remoteDeployment-tsnode/package.json
@@ -1,5 +1,4 @@
 {
-    "name": "remote-deployment",
     "devDependencies": {
         "@types/node": "^14"
     },

--- a/nodejs/ssh-tunnel/package.json
+++ b/nodejs/ssh-tunnel/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "pulumi-automation-sdk-ssh-tunnel",
-  "version": "0.0.1",
   "scripts": {
     "pulumi": "./node_modules/ts-node/dist/bin.js pulumi.ts"
   },
@@ -9,6 +7,7 @@
   },
   "dependencies": {
     "@pulumi/aws": "^4.0.0",
-    "@pulumi/pulumi": "^3.0.0"
+    "@pulumi/pulumi": "^3.0.0",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
We don't intend to publish or reference any of these, and so therefore don't need to set any names, which are optional. This removes any confusion from scanners that these might be public packages.

Did some spot testing with the ssh-tunnel example and it still works.