### PR TITLE
Add Java database migration example

### DIFF
--- a/java/databaseMigration/.gitignore
+++ b/java/databaseMigration/.gitignore
@@ -1,0 +1,18 @@
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# IDE files
+.idea/
+*.iml
+.vscode/
+.settings/
+.project
+.classpath

--- a/java/databaseMigration/README.md
+++ b/java/databaseMigration/README.md
@@ -1,0 +1,149 @@
+# Database Migration
+
+This example provisions an AWS Aurora SQL database and executes a database "migration" using the resulting connection info. This migration creates a table, inserts a few rows of data, and reads the data back to verify the setup. This is all done in a single `inline` Pulumi program. With Automation API you can orchestrate complex workflows that go beyond infrastructure provisioning and into application management, database setup, etc.
+
+To run this example you'll need a few pre-reqs:
+1. A Pulumi CLI installation ([v3.149.0](https://www.pulumi.com/docs/iac/download-install/) or later)
+2. The AWS CLI, with appropriate credentials.
+3. Install [Java 11 or later](https://www.oracle.com/java/technologies/downloads) and [Apache Maven 3.6.1 or later](https://maven.apache.org/install.html).
+
+Running this program is just like any other Java program with Maven. You can run `mvn -q compile exec:java` from the project directory.
+
+
+```shell
+$ mvn -q compile exec:java
+successfully initialized stack
+installing plugins...
+plugins installed
+setting up config...
+config set
+refreshing stack...
+Refreshing (dev)
+
+View Live: https://app.pulumi.com/user/database_migration_project/dev/updates/1
+
+
+Resources:
+
+Duration: 1s
+
+refresh complete
+updating stack...
+Updating (dev)
+
+View Live: https://app.pulumi.com/user/database_migration_project/dev/updates/2
+
+
+@ Updating.....
+ +  pulumi:pulumi:Stack database_migration_project-dev creating (0s)
+ +  aws:ec2:SecurityGroup public-security-group creating (0s)
+@ Updating....
+ +  aws:rds:SubnetGroup db-subnet creating (0s)
+@ Updating....
+ +  aws:rds:SubnetGroup db-subnet created (1s)
+@ Updating....
+ +  aws:ec2:SecurityGroup public-security-group created (2s)
+ +  aws:rds:Cluster db creating (0s)
+@ Updating.......................................................
+ +  aws:rds:Cluster db created (51s)
+ +  aws:rds:ClusterInstance db-instance creating (0s)
+@ Updating..........................................................................................................................................................................................................................................................................................................................................................................................................................
+ +  aws:rds:ClusterInstance db-instance created (406s)
+@ Updating....
+ +  pulumi:pulumi:Stack database_migration_project-dev created (462s)
+Outputs:
+    db_name: "hellosql"
+    db_pass: "hellosql"
+    db_user: "hellosql"
+    host   : "tf-20250210030519737400000001.cluster-chuqccm8uxqx.us-west-2.rds.amazonaws.com"
+
+Resources:
+    + 5 created
+
+Duration: 7m45s
+
+update summary:
+    CREATE: $d
+db host url: tf-20250210030519737400000001.cluster-chuqccm8uxqx.us-west-2.rds.amazonaws.com
+configuring db...
+db configured!
+rows inserted!
+querying to verify data...
+Result: 3 rows
+database, table, and rows successfully configured
+```
+
+To destroy the stack when you're done, invoke the program with an additional `destroy` argument:
+
+```shell
+$ mvn -q compile exec:java -Dexec.args="destroy"
+successfully initialized stack
+installing plugins...
+plugins installed
+setting up config...
+config set
+refreshing stack...
+Refreshing (dev)
+
+View Live: https://app.pulumi.com/user/database_migration_project/dev/updates/3
+
+
+@ Refreshing....
+ ~  pulumi:pulumi:Stack database_migration_project-dev refreshing (0s)
+ ~  aws:rds:SubnetGroup db-subnet refreshing (0s)
+ ~  aws:ec2:SecurityGroup public-security-group refreshing (0s)
+ ~  aws:rds:ClusterInstance db-instance refreshing (0s)
+    pulumi:pulumi:Stack database_migration_project-dev running
+ ~  aws:rds:Cluster db refreshing (0s)
+    aws:ec2:SecurityGroup public-security-group
+@ Refreshing....
+    aws:rds:Cluster db
+    aws:rds:SubnetGroup db-subnet
+    aws:rds:ClusterInstance db-instance
+    pulumi:pulumi:Stack database_migration_project-dev
+Outputs:
+    db_name: "hellosql"
+    db_pass: "hellosql"
+    db_user: "hellosql"
+    host   : "tf-20250210030519737400000001.cluster-chuqccm8uxqx.us-west-2.rds.amazonaws.com"
+
+Resources:
+    5 unchanged
+
+Duration: 3s
+
+refresh complete
+destroying stack...
+Destroying (dev)
+
+View Live: https://app.pulumi.com/user/database_migration_project/dev/updates/4
+
+
+ -  aws:rds:ClusterInstance db-instance deleting (0s)
+@ Destroying...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
+ -  aws:rds:ClusterInstance db-instance deleted (679s)
+ -  aws:rds:Cluster db deleting (0s)
+@ Destroying......................................................
+ -  aws:rds:Cluster db deleted (50s)
+ -  aws:rds:SubnetGroup db-subnet deleting (0s)
+ -  aws:ec2:SecurityGroup public-security-group deleting (0s)
+ -  aws:rds:SubnetGroup db-subnet deleted (0.21s)
+@ Destroying....
+ -  aws:ec2:SecurityGroup public-security-group deleted (0.92s)
+ -  pulumi:pulumi:Stack database_migration_project-dev deleting (0s)
+ -  pulumi:pulumi:Stack database_migration_project-dev deleted (0.09s)
+Outputs:
+  - db_name: "hellosql"
+  - db_pass: "hellosql"
+  - db_user: "hellosql"
+  - host   : "tf-20250210030519737400000001.cluster-chuqccm8uxqx.us-west-2.rds.amazonaws.com"
+
+Resources:
+    - 5 deleted
+
+Duration: 12m13s
+
+The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained.
+If you want to remove the stack completely, run `pulumi stack rm dev`.
+stack destroy complete
+```

--- a/java/databaseMigration/pom.xml
+++ b/java/databaseMigration/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>myproject</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.pulumi</groupId>
+            <artifactId>pulumi</artifactId>
+            <version>[1.2,2.0)</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pulumi</groupId>
+            <artifactId>aws</artifactId>
+            <version>6.68.0</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.example.App</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/databaseMigration/src/main/java/com/example/App.java
+++ b/java/databaseMigration/src/main/java/com/example/App.java
@@ -1,0 +1,222 @@
+package com.example;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.pulumi.Context;
+import com.pulumi.aws.ec2.Ec2Functions;
+import com.pulumi.aws.ec2.SecurityGroup;
+import com.pulumi.aws.ec2.SecurityGroupArgs;
+import com.pulumi.aws.ec2.inputs.GetSubnetsArgs;
+import com.pulumi.aws.ec2.inputs.GetSubnetsFilterArgs;
+import com.pulumi.aws.ec2.inputs.GetVpcArgs;
+import com.pulumi.aws.ec2.inputs.SecurityGroupEgressArgs;
+import com.pulumi.aws.ec2.inputs.SecurityGroupIngressArgs;
+import com.pulumi.aws.ec2.outputs.GetVpcResult;
+import com.pulumi.aws.rds.Cluster;
+import com.pulumi.aws.rds.ClusterArgs;
+import com.pulumi.aws.rds.ClusterInstance;
+import com.pulumi.aws.rds.ClusterInstanceArgs;
+import com.pulumi.aws.rds.SubnetGroup;
+import com.pulumi.aws.rds.SubnetGroupArgs;
+import com.pulumi.aws.rds.enums.EngineType;
+import com.pulumi.experimental.automation.ConfigValue;
+import com.pulumi.experimental.automation.DestroyOptions;
+import com.pulumi.experimental.automation.LocalWorkspace;
+import com.pulumi.experimental.automation.RefreshOptions;
+import com.pulumi.experimental.automation.UpOptions;
+
+public class App {
+    public static void main(String[] args) {
+
+        // Define our Pulumi program "inline"
+        Consumer<Context> program = ctx -> {
+            // Get default vpc id
+            var vpcId = Ec2Functions.getVpc(
+                    GetVpcArgs.builder().default_(true).build()
+            ).applyValue(GetVpcResult::id);
+
+            // Get public subnets
+            var subnetIds = Ec2Functions.getSubnets(GetSubnetsArgs.builder()
+                .filters(GetSubnetsFilterArgs.builder()
+                        .name("vpc-id")
+                        .values(vpcId.applyValue(List::of))
+                        .build())
+                .build())
+                .applyValue(getSubnetsResult -> getSubnetsResult.ids()
+                        .stream()
+                        .sorted()
+                        .limit(2)
+                        .collect(Collectors.toList()));
+
+            var subnetGroup = new SubnetGroup("db-subnet", SubnetGroupArgs.builder()
+                    .subnetIds(subnetIds)
+                    .build());
+
+            // Make a public security group for our cluster for the migration
+            var securityGroup = new SecurityGroup("public-security-group", SecurityGroupArgs.builder()
+                    .ingress(SecurityGroupIngressArgs.builder()
+                            .protocol("-1")
+                            .fromPort(0)
+                            .toPort(0)
+                            .cidrBlocks("0.0.0.0/0")
+                            .build())
+                    .egress(SecurityGroupEgressArgs.builder()
+                            .protocol("-1")
+                            .fromPort(0)
+                            .toPort(0)
+                            .cidrBlocks("0.0.0.0/0")
+                            .build())
+                    .build());
+
+            // For example, you should change this
+            var dbName = "hellosql";
+            var dbUser = "hellosql";
+            var dbPassword = "hellosql";
+
+            // Provision our db
+            var cluster = new Cluster("db", ClusterArgs.builder()
+                    .engine(EngineType.AuroraMysql)
+                    .engineVersion("8.0.mysql_aurora.3.08.0")
+                    .databaseName(dbName)
+                    .masterUsername(dbUser)
+                    .masterPassword(dbPassword)
+                    .skipFinalSnapshot(true)
+                    .dbSubnetGroupName(subnetGroup.name())
+                    .vpcSecurityGroupIds(securityGroup.id().applyValue(List::of))
+                    .build());
+
+            var clusterInstance = new ClusterInstance("db-instance", ClusterInstanceArgs.builder()
+                    .clusterIdentifier(cluster.clusterIdentifier())
+                    .instanceClass("db.t3.medium")
+                    .engine(EngineType.AuroraMysql.getValue())
+                    .engineVersion("8.0.mysql_aurora.3.08.0")
+                    .publiclyAccessible(true)
+                    .dbSubnetGroupName(subnetGroup.name())
+                    .build());
+
+            ctx.export("host", cluster.endpoint());
+            ctx.export("db_name", dbName);
+            ctx.export("db_user", dbUser);
+            ctx.export("db_pass", dbPassword);
+        };
+
+        // To destroy our program, we can run:
+        // mvn -q compile exec:java -Dexec.args="destroy"
+        var destroy = args.length > 0 && "destroy".equals(args[0]);
+
+        var projectName = "database_migration_project";
+        var stackName = "dev";
+
+        // Create or select a stack matching the specified name and project.
+        // This will set up a workspace with everything necessary to run our inline
+        // Pulumi program.
+        try (var stack = LocalWorkspace.createOrSelectStack(projectName, stackName, program)) {
+            System.out.println("successfully initialized stack");
+
+            // For inline programs, we must manage plugins ourselves
+            System.out.println("installing plugins...");
+            stack.getWorkspace().installPlugin("aws", "v6.68.0");
+            System.out.println("plugins installed");
+
+            // Set stack configuration specifying the region to deploy
+            System.out.println("setting up config...");
+            stack.setConfig("aws:region", new ConfigValue("us-west-2"));
+            System.out.println("config set");
+
+            // Run refresh
+            System.out.println("refreshing stack...");
+            stack.refresh(RefreshOptions.builder()
+                    .onStandardOutput(System.out::println)
+                    .build());
+            System.out.println("refresh complete");
+
+            if (destroy) {
+                System.out.println("destroying stack...");
+                stack.destroy(DestroyOptions.builder()
+                        .onStandardOutput(System.out::println)
+                        .build());
+                System.out.println("stack destroy complete");
+                return;
+            }
+
+            System.out.println("updating stack...");
+            var result = stack.up(UpOptions.builder()
+                    .onStandardOutput(System.out::println)
+                    .build());
+
+            var changes = result.getSummary().getResourceChanges();
+            if (!changes.isEmpty()) {
+                System.out.println("update summary:");
+                changes.forEach((key, value) -> {
+                    System.out.printf("    %s: $d%n", key, value);
+                });
+            }
+
+            System.out.printf("db host url: %s%n", result.getOutputs().get("host").getValue());
+            configureDatabase(
+                    (String) result.getOutputs().get("host").getValue(),
+                    (String) result.getOutputs().get("db_name").getValue(),
+                    (String) result.getOutputs().get("db_user").getValue(),
+                    (String) result.getOutputs().get("db_pass").getValue());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    static void configureDatabase(String host, String database, String user, String password) throws SQLException {
+        System.out.println("configuring db...");
+
+        // Register JDBC driver
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new SQLException("MySQL JDBC Driver not found", e);
+        }
+
+        var url = String.format("jdbc:mysql://%s/%s",
+                host,
+                database);
+
+        try (var connection = DriverManager.getConnection(url, user, password)) {
+            System.out.println("db configured!");
+
+            // Make sure the table exists
+            var createTableQuery = "CREATE TABLE IF NOT EXISTS hello_pulumi(" +
+                    "id int(9) NOT NULL PRIMARY KEY, " +
+                    "color varchar(14) NOT NULL);";
+
+            try (var createStatement = connection.prepareStatement(createTableQuery)) {
+                createStatement.executeUpdate();
+            }
+
+            // Seed the table with some data to start
+            var seedTableQuery = "INSERT IGNORE INTO hello_pulumi (id, color) " +
+                    "VALUES " +
+                    "    (1, 'Purple'), " +
+                    "    (2, 'Violet'), " +
+                    "    (3, 'Plum');";
+
+            try (var seedStatement = connection.prepareStatement(seedTableQuery)) {
+                seedStatement.executeUpdate();
+            }
+
+            System.out.println("rows inserted!");
+            System.out.println("querying to verify data...");
+
+            var readTableQuery = "SELECT COUNT(*) FROM hello_pulumi;";
+            try (var readStatement = connection.prepareStatement(readTableQuery)) {
+                var resultSet = readStatement.executeQuery();
+                if (resultSet.next()) {
+                    System.out.println("Result: " + resultSet.getInt(1) + " rows");
+                }
+            }
+
+            System.out.println("database, table, and rows successfully configured");
+        }
+    }
+}


### PR DESCRIPTION
Adds a Java database migration example that uses Automation API with an inline program to provision an AWS Aurora SQL database with Pulumi and then executes a database "migration" using the resulting connection info.